### PR TITLE
Add missing package

### DIFF
--- a/debian.Dockerfile
+++ b/debian.Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update                                  \
         ca-certificates                             \
         rsync                                       \
         iproute2                                    \
+        python3-apt                                 \
     &&  apt-get clean                               \
     &&  rm -rf                                      \
         /var/lib/apt/lists/*                        \


### PR DESCRIPTION
Running the apt ansible module on debian 11 requires an additional python3 package.